### PR TITLE
Find bugs update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@
 **/*.pmdruleset.xml
 .idea/
 *.iml
-.idea/
-*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 *dependency-reduced-pom.xml
 **/*.pmd
 **/*.pmdruleset.xml
+.idea/
+*.iml
+.idea/
+*.iml

--- a/authzforce-xacmlsdk-core/pom.xml
+++ b/authzforce-xacmlsdk-core/pom.xml
@@ -124,7 +124,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>findbugs-maven-plugin</artifactId>
-						<version>3.0.2</version>
+						<version>3.0.4</version>
 						<configuration>
 							<!-- Enables analysis which takes more memory but finds more bugs. 
 								If you run out of memory, changes the value of the effort element to 'Low'. -->


### PR DESCRIPTION
Fixes #1.

@cdanger / @hargathor   Ideally findbugs should be replaced since is no [longer maintained](https://gleclaire.github.io/findbugs-maven-plugin/). Consider [SpotBugs]( https://spotbugs.github.io/), it seems to be the spiritual successor