### PR TITLE
Add prefix to samples PDP URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The PDP provides an API for getting authorization decisions computed by a XACML-
 
 * `getAuthz` to get the computed decision
 
-see the [PDP samples](authzforce-xacmlsdk-samples/src/main/java/org/ow2/authzforce/sdk/main) for usage examples
+see the [PDP samples](authzforce-xacmlsdk-samples/src/main/java/org/ow2/authzforce/sdk/pdp) for usage examples
 
 The PAP provides API for managing XACML policies to be handled by the Authorization Service PDP. It supports the following actions
 

--- a/authzforce-xacmlsdk-samples/src/main/java/org/ow2/authzforce/sdk/utils/ServerSetup.java
+++ b/authzforce-xacmlsdk-samples/src/main/java/org/ow2/authzforce/sdk/utils/ServerSetup.java
@@ -20,7 +20,7 @@ public class ServerSetup {
     }
 
     public static URI getRootURL(GenericContainer server) {
-        return UriBuilder.fromUri("authzforce-ce")
+        return UriBuilder.fromUri("/authzforce-ce")
                 .scheme("http")
                 .host(server.getContainerIpAddress())
                 .port(server.getMappedPort(PORT))


### PR DESCRIPTION
This change fixes the examples from `authzforce-xacmlsdk-samples`, which failed to establish a connection to the containerized PDP (generally `http://localhost:{{random port}}/authzforce-ce`). The exception being generated was:

```
Exception in thread "main" org.ow2.authzforce.sdk.exceptions.XacmlSdkException: javax.ws.rs.ProcessingException: java.lang.IllegalArgumentException: IllegalArgumentException invoking http:authzforce-ce: protocol = http host = null
	at org.ow2.authzforce.sdk.impl.AdminXacmlSdkImpl.addDomain(AdminXacmlSdkImpl.java:74)
	at org.ow2.authzforce.sdk.utils.PapService.setupBasicDomain(PapService.java:15)
	at org.ow2.authzforce.sdk.pdp.SimpleAuthorizationRequest.main(SimpleAuthorizationRequest.java:42)
Caused by: javax.ws.rs.ProcessingException: java.lang.IllegalArgumentException: IllegalArgumentException invoking http:authzforce-ce: protocol = http host = null
	at org.apache.cxf.jaxrs.client.AbstractClient.checkClientException(AbstractClient.java:557)
	at org.apache.cxf.jaxrs.client.AbstractClient.preProcessResult(AbstractClient.java:539)
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.doChainedInvocation(ClientProxyImpl.java:690)
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.invoke(ClientProxyImpl.java:227)
	at com.sun.proxy.$Proxy30.addDomain(Unknown Source)
	at org.ow2.authzforce.sdk.impl.AdminXacmlSdkImpl.addDomain(AdminXacmlSdkImpl.java:67)
	... 2 more
Caused by: java.lang.IllegalArgumentException: IllegalArgumentException invoking http:authzforce-ce: protocol = http host = null
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.mapException(HTTPConduit.java:1365)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1354)
	at org.apache.cxf.io.CacheAndWriteOutputStream.postClose(CacheAndWriteOutputStream.java:56)
	at org.apache.cxf.io.CachedOutputStream.close(CachedOutputStream.java:215)
	at org.apache.cxf.transport.AbstractConduit.close(AbstractConduit.java:56)
	at org.apache.cxf.transport.http.HTTPConduit.close(HTTPConduit.java:652)
	at org.apache.cxf.interceptor.MessageSenderInterceptor$MessageSenderEndingInterceptor.handleMessage(MessageSenderInterceptor.java:62)
	at org.apache.cxf.phase.PhaseInterceptorChain.doIntercept(PhaseInterceptorChain.java:307)
	at org.apache.cxf.jaxrs.client.AbstractClient.doRunInterceptorChain(AbstractClient.java:624)
	at org.apache.cxf.jaxrs.client.ClientProxyImpl.doChainedInvocation(ClientProxyImpl.java:688)
	... 5 more
Caused by: java.lang.IllegalArgumentException: protocol = http host = null
	at sun.net.spi.DefaultProxySelector.select(DefaultProxySelector.java:177)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1156)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056)
	at sun.net.www.protocol.http.HttpURLConnection.connect(HttpURLConnection.java:990)
	at sun.net.www.protocol.http.HttpURLConnection.getOutputStream0(HttpURLConnection.java:1340)
	at sun.net.www.protocol.http.HttpURLConnection.getOutputStream(HttpURLConnection.java:1315)
	at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream.setupWrappedStream(URLConnectionHTTPConduit.java:183)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.handleHeadersTrustCaching(HTTPConduit.java:1308)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.onFirstWrite(HTTPConduit.java:1268)
	at org.apache.cxf.transport.http.URLConnectionHTTPConduit$URLConnectionWrappedOutputStream.onFirstWrite(URLConnectionHTTPConduit.java:210)
	at org.apache.cxf.io.AbstractWrappedOutputStream.write(AbstractWrappedOutputStream.java:47)
	at org.apache.cxf.io.AbstractThresholdOutputStream.write(AbstractThresholdOutputStream.java:69)
	at org.apache.cxf.transport.http.HTTPConduit$WrappedOutputStream.close(HTTPConduit.java:1321)
	... 13 more

```

Tested on...
- OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_212-b03)
- OpenJDK Runtime Environment Corretto-8.342.07.1 (build 1.8.0_342-b07)
